### PR TITLE
Fix migrations.rst

### DIFF
--- a/migrations.rst
+++ b/migrations.rst
@@ -29,7 +29,7 @@ Migrations are typically paired with the :ref:`SchemaBuilder` to easily manage y
                 driver: mysql
                 host: localhost
                 database: database
-                username: root
+                user: root
                 password: ''
                 prefix: ''
 
@@ -42,7 +42,7 @@ Migrations are typically paired with the :ref:`SchemaBuilder` to easily manage y
                 'driver': 'mysql',
                 'host': 'localhost',
                 'database': 'database',
-                'username': 'root',
+                'user': 'root',
                 'password': '',
                 'prefix': ''
             }


### PR DESCRIPTION
Using `username` gets error:

```
[TypeError]
  __init__() got an unexpected keyword argument 'username'
```

After some tries, I find `user` is the correct argument.
